### PR TITLE
chore: Add 'validate-renovate-config / validate' default status check

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,7 @@ variable "required_status_checks" {
     "lint / lint",
     "test / test",
     "build-container-image / build",
+    "validate-renovate-config / validate",
   ]
   description = "The list of status checks that need to pass for PRs"
 }


### PR DESCRIPTION
BREAKING CHANGE: This adds a new required status check to the default list. Add the following job to your projects to include this job:
```yaml
validate-renovate-config:
  uses: BlindfoldedSurgery/renovate-config/.github/workflows/validate.yml@main
```