### PR TITLE
chore!: Disable squash-and-merge by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "github_repository" "main" {
   delete_branch_on_merge = true
 
   allow_merge_commit = false
-  allow_squash_merge = true
+  allow_squash_merge = var.allow_squash_merge
   allow_rebase_merge = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "required_status_checks" {
   ]
   description = "The list of status checks that need to pass for PRs"
 }
+
+variable "allow_squash_merge" {
+  type        = bool
+  default     = false
+  description = "Allow PRs to be merged by squashing the PR's commits"
+}


### PR DESCRIPTION
BREAKING CHANGE: This update disables the option to merge PRs by squashing. Can be overriden using the new `allow_squash_merge` variable.