### PR TITLE
fix: remove redundant etag ignores

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,12 +86,6 @@ resource "github_repository_ruleset" "default_forceless" {
     deletion         = true
     non_fast_forward = true
   }
-
-  lifecycle {
-    ignore_changes = [
-      etag,
-    ]
-  }
 }
 
 resource "github_repository_ruleset" "default_checks" {
@@ -133,12 +127,6 @@ resource "github_repository_ruleset" "default_checks" {
       }
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      etag,
-    ]
-  }
 }
 
 resource "github_repository_ruleset" "argocd" {
@@ -171,12 +159,6 @@ resource "github_repository_ruleset" "argocd" {
       }
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      etag,
-    ]
-  }
 }
 
 resource "github_repository_ruleset" "blocked" {
@@ -198,12 +180,6 @@ resource "github_repository_ruleset" "blocked" {
     creation         = true
     update           = true
     non_fast_forward = true
-  }
-
-  lifecycle {
-    ignore_changes = [
-      etag,
-    ]
   }
 }
 


### PR DESCRIPTION
This reverts commit 4054a6fb834413b92847147f8b8c841e54ce97b1.